### PR TITLE
Fix CLI startup on modern Node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 
-require = require('esm')(module);
-require('./src/cli').cli(process.argv);
+import { cli } from './src/cli.js';
+
+cli(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "conf": "^15.0.2",
-        "esm": "^3.2.25",
         "minimist": "^1.2.8"
       },
       "bin": {
@@ -285,14 +284,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -804,11 +795,6 @@
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       }
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "best-weather-cli",
   "version": "1.0.3",
   "description": "A weather CLI app in Node.js. The app checks weather in command line.",
+  "type": "module",
   "main": "index.js",
   "bin": {
     "weather": "./index.js"
@@ -31,7 +32,6 @@
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "conf": "^15.0.2",
-    "esm": "^3.2.25",
     "minimist": "^1.2.8"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,9 @@
 import minimist from 'minimist';
-import { now } from './now';
-import { forecast } from './forecast';
-import { help } from './help';
-import { configure } from './configure';
-import { version } from './version';
+import { now } from './now.js';
+import { forecast } from './forecast.js';
+import { help } from './help.js';
+import { configure } from './configure.js';
+import { version } from './version.js';
 
 export async function cli(argsArray) {
   const args = minimist(argsArray.slice(2));

--- a/src/configure.js
+++ b/src/configure.js
@@ -1,5 +1,5 @@
 import Conf from 'conf';
-import { validateApiKey, validateCityId, validateUnits } from './utils';
+import { validateApiKey, validateCityId, validateUnits } from './utils.js';
 
 export const configKey = 'weather-cli';
 

--- a/src/forecast.js
+++ b/src/forecast.js
@@ -1,12 +1,12 @@
 import Conf from 'conf';
 import Table from 'cli-table3';
-import { configKey } from './configure';
+import { configKey } from './configure.js';
 import {
   validateApiKey,
   validateCityId,
   validateUnits,
   queryWeatherForecast,
-} from './utils';
+} from './utils.js';
 
 export async function forecast(args) {
   const config = new Conf().get(configKey);

--- a/src/now.js
+++ b/src/now.js
@@ -1,12 +1,12 @@
 import Conf from 'conf';
 import Table from 'cli-table3';
-import { configKey } from './configure';
+import { configKey } from './configure.js';
 import {
   validateApiKey,
   validateCityId,
   validateUnits,
   queryCurrentWeather
-} from './utils';
+} from './utils.js';
 
 export async function now(args) {
   const config = new Conf().get(configKey);

--- a/src/version.js
+++ b/src/version.js
@@ -1,3 +1,7 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
 export async function version() {
   const packageJson = require('../package.json');
   console.log(packageJson.version);


### PR DESCRIPTION
Fixes #14.

## Summary
- switch the CLI entrypoint from the legacy `esm` loader to native Node ESM
- add explicit `.js` extensions for local ESM imports
- remove the `esm` runtime dependency
- keep `version` working in ESM via `createRequire`

## Verification
- `node index.js --help` and `node index.js --version` on Node v25.8.2
- `npx -y node@20 index.js --help` and `npx -y node@20 index.js --version`
- `npx -y node@22 index.js --help` and `npx -y node@22 index.js --version`
- `npm pack`, clean install the tarball, then verify `--help` / `--version` on Node 20, Node 22, and Node v25.8.2